### PR TITLE
feat(#2): remove `memory_time_megabyte_seconds` and `cpu_time_seconds`

### DIFF
--- a/src/jobs/models/job.dto.ts
+++ b/src/jobs/models/job.dto.ts
@@ -205,22 +205,6 @@ export class Job {
   dependency_status?: string;
 
   @IsOptional()
-  @IsPositive()
-  @ApiProperty({
-    description: 'Memory time in MB/s used by the job',
-    required: false,
-  })
-  memory_time_megabyte_seconds?: number;
-
-  @IsOptional()
-  @IsPositive()
-  @ApiProperty({
-    description: 'CPU time in seconds used by the job',
-    required: false,
-  })
-  cpu_time_seconds?: number;
-
-  @IsOptional()
   @ApiProperty({
     description: 'Geometry processed by the job',
     required: false,

--- a/src/jobs/services/database/config/index_create.json
+++ b/src/jobs/services/database/config/index_create.json
@@ -78,12 +78,6 @@
       "dependency_status": {
         "type": "keyword"
       },
-      "memory_time_megabyte_seconds": {
-        "type": "long"
-      },
-      "cpu_time_seconds": {
-        "type": "long"
-      },
       "geometry": {
         "type": "object"
       },


### PR DESCRIPTION
already covered by generic `usage`

see #2 