### PR TITLE
fix: "process" and "job_options" are create-only fields

### DIFF
--- a/src/jobs/models/job.dto.ts
+++ b/src/jobs/models/job.dto.ts
@@ -73,13 +73,6 @@ export class PatchJob {
 
   @IsOptional()
   @ApiProperty({
-    description: 'Processing graph used by the job',
-    required: false,
-  })
-  specification?: any;
-
-  @IsOptional()
-  @ApiProperty({
     description: 'ID of the application linked to the job',
     required: false,
   })
@@ -179,13 +172,6 @@ export class PatchJob {
 
   @IsOptional()
   @ApiProperty({
-    description: 'User specified options related to the job execution',
-    required: false,
-  })
-  job_options?: any;
-
-  @IsOptional()
-  @ApiProperty({
     description: 'Metadata about the batch job results and assets',
     required: false,
   })
@@ -218,4 +204,18 @@ export class Job extends PatchJob {
     required: false,
   })
   user_id?: string;
+
+  @IsOptional()
+  @ApiProperty({
+    description: 'Process graph of the job',
+    required: false,
+  })
+  process?: any;
+
+  @IsOptional()
+  @ApiProperty({
+    description: 'User specified options related to the job execution',
+    required: false,
+  })
+  job_options?: any;
 }


### PR DESCRIPTION
since the strict validation of c3f5d60e5ebbd2babb1b229e739025137e63ae1e , usage of the "process" field blocked job creation.
The field "specification" was there, but that's legacy and now overruled by "process".

this PR replaces "specification" with "process"
and makes "process" and "job_options"  create-only fields (also see #16 )