### PR TITLE
fix: add caching to token introspect request

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -4,23 +4,26 @@ import { APP_GUARD, Reflector } from '@nestjs/core';
 import { ConfigService } from '../config/config/config.service';
 import { BearerStrategy, buildBearerClient } from './bearer/bearer.strategy';
 import { AuthService } from './services/auth.service';
+import { CachingModule } from '../caching/caching.module';
+import { CachingService } from '../caching/services/cache.service';
 
 const BearerStrategyFactory = {
   provide: 'BearerStrategy',
   useFactory: async (
     configService: ConfigService,
     authService: AuthService,
+    cachingService: CachingService,
   ) => {
     const client = await buildBearerClient(configService); // secret sauce! build the dynamic client before injecting it into the strategy for use in the constructor super call.
-    const strategy = new BearerStrategy(client);
+    const strategy = new BearerStrategy(client, cachingService);
     authService.setAuthClient(client);
     return strategy;
   },
-  inject: [ConfigService, AuthService],
+  inject: [ConfigService, AuthService, CachingService],
 };
 
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, CachingModule],
   providers: [
     Logger,
     AuthService,

--- a/src/auth/bearer/bearer.strategy.spec.ts
+++ b/src/auth/bearer/bearer.strategy.spec.ts
@@ -1,8 +1,14 @@
 import { BearerStrategy, VERIFICATION_ERRORS } from './bearer.strategy';
+import { CachingService } from '../../caching/services/cache.service';
 
 describe('BearerStrategy', () => {
   const mockClient: any = {
     introspect: (token: string) => Promise<any>,
+  };
+
+  const mockCachingService: jest.Mocked<Pick<CachingService, 'checkCache' | 'store'>> = {
+    checkCache: jest.fn(),
+    store: jest.fn(),
   };
 
   afterEach(() => {
@@ -11,7 +17,9 @@ describe('BearerStrategy', () => {
   });
 
   it('should return an error when there is no client defined', async () => {
-    const strategy = new BearerStrategy(null);
+    mockCachingService.checkCache.mockResolvedValueOnce(undefined);
+    mockCachingService.store.mockResolvedValueOnce(undefined);
+    const strategy = new BearerStrategy(null, mockCachingService as any);
     const verified = jest.fn();
     const verifyMock = jest
       .spyOn(mockClient, 'introspect')
@@ -31,7 +39,9 @@ describe('BearerStrategy', () => {
   });
 
   it('should verify the token', async () => {
-    const strategy = new BearerStrategy(mockClient);
+    mockCachingService.checkCache.mockResolvedValueOnce(undefined);
+    mockCachingService.store.mockResolvedValueOnce(undefined);
+    const strategy = new BearerStrategy(mockClient, mockCachingService as any);
     const verified = jest.fn();
     const verifyMock = jest
       .spyOn(mockClient, 'introspect')
@@ -44,10 +54,12 @@ describe('BearerStrategy', () => {
     expect(verifyMock).toBeCalledTimes(1);
     expect(verified.mock.calls.length).toEqual(1);
     expect(verified.mock.calls[0]).toEqual([null, {}, null]);
+    expect(mockCachingService.store).toBeCalledTimes(1);
   });
 
   it('should not verify token if not active', async () => {
-    const strategy = new BearerStrategy(mockClient);
+    mockCachingService.checkCache.mockResolvedValueOnce(undefined);
+    const strategy = new BearerStrategy(mockClient, mockCachingService as any);
     const verified = jest.fn();
     const verifyMock = jest.spyOn(mockClient, 'introspect').mockResolvedValue({
       active: false,
@@ -62,10 +74,12 @@ describe('BearerStrategy', () => {
       null,
       VERIFICATION_ERRORS.TOKEN_INVALID,
     ]);
+    expect(mockCachingService.store).toBeCalledTimes(0);
   });
 
   it('should not validate the token if an error occurred during the token validation', async () => {
-    const strategy = new BearerStrategy(mockClient);
+    mockCachingService.checkCache.mockResolvedValueOnce(undefined);
+    const strategy = new BearerStrategy(mockClient, mockCachingService as any);
     const verified = jest.fn();
     const verifyMock = jest
       .spyOn(mockClient, 'introspect')
@@ -82,5 +96,21 @@ describe('BearerStrategy', () => {
       null,
       null,
     ]);
+    expect(mockCachingService.store).toBeCalledTimes(0);
+  });
+
+  it('should return cached result and skip introspection on cache hit', async () => {
+    const cachedResult = { error: null, user: {}, info: null };
+    mockCachingService.checkCache.mockResolvedValueOnce(cachedResult);
+    const strategy = new BearerStrategy(mockClient, mockCachingService as any);
+    const verified = jest.fn();
+    const verifyMock = jest.spyOn(mockClient, 'introspect');
+
+    await strategy.verify('token', verified, 3);
+
+    expect(verifyMock).toBeCalledTimes(0);
+    expect(mockCachingService.store).toBeCalledTimes(0);
+    expect(verified.mock.calls.length).toEqual(1);
+    expect(verified.mock.calls[0]).toEqual([null, {}, null]);
   });
 });

--- a/src/auth/bearer/bearer.strategy.ts
+++ b/src/auth/bearer/bearer.strategy.ts
@@ -4,6 +4,7 @@ import { Strategy } from 'passport-http-bearer';
 import { ConfigService } from '../../config/config/config.service';
 import { Client, custom, IntrospectionResponse, Issuer } from 'openid-client';
 import { UtilsService } from '../../utils/services/utils/utils.service';
+import { CachingService } from '../../caching/services/cache.service';
 
 export enum VERIFICATION_ERRORS {
   NO_CLIENT = 'no_client',
@@ -32,17 +33,37 @@ export const buildBearerClient = async (configService: ConfigService) => {
 export class BearerStrategy extends PassportStrategy(Strategy, 'bearer') {
   client: Client;
   logger: Logger;
+  cachingService: CachingService;
 
-  constructor(client: Client) {
+  constructor(client: Client, cachingService: CachingService) {
     super({}, (token, verified) => this.verify(token, verified, 5));
     this.client = client;
+    this.cachingService = cachingService;
     this.logger = new Logger('BearerStrategy');
   }
+
+  private getCacheKey(token: string): string {
+    return `bearer:${token}`;
+  }
+
   public async verify(
     token: string,
     verified: (error, user, info) => void,
     attempts: number,
   ) {
+    const cacheKey = this.getCacheKey(token);
+    const cachedResult = await this.cachingService.checkCache<{
+      error?: VERIFICATION_ERRORS;
+      user?: any;
+      info?: string;
+    }>(cacheKey);
+
+    if (cachedResult !== undefined) {
+      this.logger.debug('Token found in cache, skipping introspection');
+      verified(cachedResult.error, cachedResult.user, cachedResult.info);
+      return;
+    }
+
     let attempt = 1;
     let introspectResult;
 
@@ -55,6 +76,10 @@ export class BearerStrategy extends PassportStrategy(Strategy, 'bearer') {
       }
       await UtilsService.sleep(1000);
       attempt += 1;
+    }
+
+    if (!introspectResult.error && introspectResult.user) {
+      await this.cachingService.store(cacheKey, introspectResult);
     }
 
     verified(


### PR DESCRIPTION
Since the API calls are mainly coming from openeo, adding caching to token verification will help to reduce the overall response time.